### PR TITLE
Add message statistics and speedtest messages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,22 @@ permissions:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64
+          - runner: ubuntu-latest
+            target: x86
+          - runner: ubuntu-latest
+            target: aarch64
+          - runner: ubuntu-latest
+            target: armv7
+          - runner: ubuntu-latest
+            target: s390x
+          - runner: ubuntu-latest
+            target: ppc64le
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/set-version
@@ -25,20 +37,24 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist -i 3.8 -i 3.9 -i 3.10 -i 3.11 -i 3.12
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-linux-${{ matrix.platform.target }}
           path: dist
 
   windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        target: [x64, x86]
+        platform:
+          - runner: windows-latest
+            target: x64
+          - runner: windows-latest
+            target: x86
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/set-version
@@ -50,19 +66,23 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist -i 3.8 -i 3.9 -i 3.10 -i 3.11 -i 3.12
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-windows-${{ matrix.platform.target }}
           path: dist
 
   macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        target: [x86_64, aarch64]
+        platform:
+          - runner: macos-13
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/set-version
@@ -73,12 +93,12 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist -i 3.8 -i 3.9 -i 3.10 -i 3.11 -i 3.12
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos-${{ matrix.platform.target }}
           path: dist
 
   sdist:
@@ -92,9 +112,9 @@ jobs:
           command: sdist
           args: --out dist
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-sdist
           path: dist
 
   release:
@@ -103,13 +123,11 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, windows, macos, sdist]
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
+      - uses: actions/download-artifact@v4
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         with:
           command: upload
-          args: --non-interactive --skip-existing *
+          args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
           toolchain: stable
           components: rustfmt
           target: x86_64-unknown-linux-gnu
-      - name: Setup Python 3.8
-        uses: actions/setup-python@v4
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Setup dependencies
         run: |
           pip install --upgrade pip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "rust_endpoint"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.20.0", features = ["extension-module"] }
+pyo3 = { version = "0.23.4", features = ["extension-module"] }
 tokio = { version = "1.43.0", features = ["full"] }
 env_logger = "0.11.6"
 log = "0.4.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.20.0", features = ["extension-module"] }
-tokio = { version = "1.34.0", features = ["full"] }
-env_logger = "0.10.1"
-log = "0.4.20"
-arc-swap = "1.6.0"
+tokio = { version = "1.43.0", features = ["full"] }
+env_logger = "0.11.6"
+log = "0.4.25"
+arc-swap = "1.7.1"
 chacha20poly1305 = "0.10.1"
-socks5-proto = "0.4.0"
-socks5-server = "0.10.0"
-bytes = "1.5.0"
-rand = "0.8.5"
-map-macro = "0.2.6"
+socks5-proto = "0.4.1"
+socks5-server = "0.10.1"
+bytes = "1.10.0"
+rand = "0.9.0"
+map-macro = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # IPv8-rust-tunnels
-[![](https://img.shields.io/pypi/v/ipv8-rust-tunnels.svg?label=PyPI)](https://pypi.org/project/ipv8-rust-tunnels/) &emsp; ![Unit tests](https://github.com/egbertbouman/ipv8-rust-tunnels/actions/workflows/test.yml/badge.svg)
+[![](https://img.shields.io/pypi/v/ipv8-rust-tunnels.svg?label=PyPI)](https://pypi.org/project/ipv8-rust-tunnels/) &emsp; ![Unit tests](https://github.com/Tribler/ipv8-rust-tunnels/actions/workflows/test.yml/badge.svg)
 
 This module provides a set of performance enhancements to the `TunnelCommunity`, the anonymization layer used in [IPv8](https://github.com/Tribler/py-ipv8) and [Tribler](https://github.com/Tribler/tribler). It works by handling the tunnel data traffic in Rust, while letting the Python anonymization layer handle the tunnel control logic.

--- a/ipv8_rust_tunnels/endpoint.py
+++ b/ipv8_rust_tunnels/endpoint.py
@@ -78,6 +78,25 @@ class RustEndpoint(CryptoEndpoint, Endpoint, TaskManager):
         for exit_socket in self.exit_sockets.values():
             self.rust_ep.update_exit_stats(exit_socket.circuit_id, exit_socket)
 
+    def get_statistics(self, prefix: bytes) -> dict[int, NetworkStat]:
+        """
+        Get the message statistics per message identifier for the given prefix.
+        """
+        result = {}
+        for msg_id, counters in self.rust_ep.get_message_statistics(prefix).items():
+            stat = result[msg_id] = NetworkStat(msg_id)
+            stat.num_up = counters[0]
+            stat.num_down = counters[2]
+            stat.bytes_up = counters[1]
+            stat.bytes_down = counters[3]
+        return result
+
+    def enable_community_statistics(self, community_prefix: bytes, enabled: bool) -> None:
+        """
+        Start tracking stats for packets with the given prefix.
+        """
+        pass
+
     def setup_tunnels(self, tunnel_community: TunnelCommunity, settings: TunnelSettings) -> None:
         """
         Set up the TunnelCommunity.

--- a/ipv8_rust_tunnels/tests/test_tunnel_community.py
+++ b/ipv8_rust_tunnels/tests/test_tunnel_community.py
@@ -1,7 +1,9 @@
 import unittest
+from unittest.mock import Mock
 
 from ipv8_rust_tunnels.endpoint import RustEndpoint
 
+from ipv8.messaging.interfaces.endpoint import EndpointListener
 from ipv8.messaging.interfaces.udp.endpoint import UDPv4Address
 from ipv8.test.messaging.anonymization.test_community import TestTunnelCommunity
 from ipv8.test.messaging.anonymization.test_hiddenservices import TestHiddenServices
@@ -25,6 +27,12 @@ def create_node(org, *args, **kwargs):  # noqa: ANN201, ANN002, ANN001, D103
     ep.setup_tunnels(overlay, overlay.settings)
     ep.remove_listener(ipv8.overlay)
     ep.add_prefix_listener(ipv8.overlay, overlay.get_prefix())
+
+    # Some unittests use prefixes that we don't want blocked. So, we add a fake EndpointListener.
+    mock = Mock()
+    mock.__class__ = EndpointListener
+    ep.add_prefix_listener(mock, b'\x00' * 22)
+    ep.add_prefix_listener(mock, b'\x00\x01' + b'\x00' * 20)
 
     overlay.circuits = ep.circuits
     overlay.relay_from_to = ep.relays

--- a/ipv8_rust_tunnels/tests/test_tunnel_community.py
+++ b/ipv8_rust_tunnels/tests/test_tunnel_community.py
@@ -1,8 +1,11 @@
+import asyncio
 import unittest
 from unittest.mock import Mock
 
 from ipv8_rust_tunnels.endpoint import RustEndpoint
 
+from ipv8.messaging.anonymization.community import CIRCUIT_TYPE_RP_DOWNLOADER
+from ipv8.messaging.anonymization.tunnel import PEER_FLAG_SPEED_TEST
 from ipv8.messaging.interfaces.endpoint import EndpointListener
 from ipv8.messaging.interfaces.udp.endpoint import UDPv4Address
 from ipv8.test.messaging.anonymization.test_community import TestTunnelCommunity
@@ -49,16 +52,69 @@ def replace(old_func, new_func):  # noqa: ANN001, D103, ANN201
     return lambda *args, org=old_func, **kwargs: new_func(org, *args, **kwargs)
 
 
+async def new_test_test_request(self) -> None:
+    """
+    Check if sending test-request messages works as expected.
+    """
+    self.add_node_to_experiment(self.create_node())
+    self.settings(1).peer_flags |= {PEER_FLAG_SPEED_TEST}
+    await self.introduce_nodes()
+    circuit = self.overlay(0).create_circuit(2, exit_flags=[PEER_FLAG_SPEED_TEST])
+    await circuit.ready
+
+    callback = Mock()
+    self.overlay(0).endpoint.run_speedtest(circuit.circuit_id, 10, 10, 10, 1, callback)
+    await asyncio.sleep(.1)
+
+    callback.assert_called_once()
+    self.assertEqual(len(callback.call_args_list), 1)
+    msg_stats = list(callback.call_args_list[0].args[0].values())
+    self.assertTrue(sum([stat[1] for stat in msg_stats]) > 0)
+    self.assertTrue(sum([stat[3] for stat in msg_stats]) > 0)
+
+
+async def new_test_test_request_e2e(self, *args) -> None:
+    """
+    Check if sending test-request messages over an e2e circuit works as expected.
+    """
+    future = asyncio.Future()
+
+    self.overlay(0).join_swarm(self.service, 1, future.set_result, seeding=False)
+    self.overlay(2).join_swarm(self.service, 1, future.set_result)
+    self.overlay(2).settings.peer_flags.add(PEER_FLAG_SPEED_TEST)
+
+    await self.introduce_nodes()
+    await self.create_intro(2, self.service)
+    await self.assign_exit_node(0)
+
+    await self.overlay(0).do_peer_discovery()
+    await self.deliver_messages()
+
+    await future
+
+    circuit, = self.overlay(0).find_circuits(ctype=CIRCUIT_TYPE_RP_DOWNLOADER)
+    callback = Mock()
+    self.overlay(0).endpoint.run_speedtest(circuit.circuit_id, 10, 3, 6, 1, callback)
+    await asyncio.sleep(.1)
+
+    callback.assert_called_once()
+    self.assertEqual(len(callback.call_args_list), 1)
+    msg_stats = list(callback.call_args_list[0].args[0].values())
+    self.assertTrue(sum([stat[1] for stat in msg_stats]) > 0)
+    self.assertTrue(sum([stat[3] for stat in msg_stats]) > 0)
+
+
 TestTunnelCommunity.create_node = replace(TestTunnelCommunity.create_node, create_node)
 TestTunnelCommunity.setUp = replace(TestTunnelCommunity.setUp, set_up)
+TestTunnelCommunity.test_test_request = new_test_test_request
 TestTunnelCommunity.test_tunnel_unicode_destination = \
     unittest.skip("not available in RustEndpoint")(TestTunnelCommunity.test_tunnel_unicode_destination)
 
 TestHiddenServices.create_node = replace(TestHiddenServices.create_node, create_node)
 TestHiddenServices.setUp = replace(TestHiddenServices.setUp, set_up)
+TestHiddenServices.test_test_request_e2e = new_test_test_request_e2e
 TestHiddenServices.test_dht_lookup_with_counterparty = \
     unittest.skip("not available in RustEndpoint")(TestHiddenServices.test_dht_lookup_with_counterparty)
-
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "ipv8-rust-tunnels"
 description = "IPv8 tunnel performance enhancements"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,6 +558,7 @@ pub fn ipv8_rust_tunnels(py: Python, module: &Bound<'_, PyModule>) -> PyResult<(
     env_logger::init();
     module.add("RustError", py.get_type::<RustError>())?;
     module.add_class::<Endpoint>()?;
+    module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,26 +207,35 @@ impl Endpoint {
 
     fn run_speedtest(
         &mut self,
-        server_addr: String,
-        associate_port: u16,
-        num_packets: usize,
+        circuit_id: u32,
+        test_time: u16,
         request_size: u16,
         response_size: u16,
-        timeout_ms: usize,
-        window_size: usize,
+        target_rtt: u16,
         callback: PyObject,
+        callback_interval: u16,
     ) -> PyResult<()> {
-        let settings = self.settings.clone().unwrap().clone();
-        settings.load().handle.spawn(speedtest::run_speedtest(
-            server_addr,
-            associate_port,
-            num_packets,
+        let Some(settings) = &self.settings else {
+            return Err(RustError::new_err("No settings available"));
+        };
+
+        let Some(socket) = self.socket.clone() else {
+            return Err(RustError::new_err("Socket is not open"));
+        };
+
+        settings.load().handle.spawn(speedtest::run_test(
+            settings.clone(),
+            circuit_id,
+            self.circuits.clone(),
+            socket,
+            test_time,
             request_size,
             response_size,
-            timeout_ms,
-            window_size,
+            target_rtt,
             callback,
+            callback_interval,
         ));
+
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ impl Endpoint {
 
     fn open(&mut self, callback: PyObject, worker_threads: usize) -> PyResult<()> {
         if self.socket.is_some() {
-            return Err(RustError::new_err("Endpoint.open was called behore"));
+            return Err(RustError::new_err("Endpoint is already open"));
         }
 
         info!("Spawning Tokio thread");
@@ -137,6 +137,10 @@ impl Endpoint {
                 error!("Unable to shutdown Tokio thread: {:?}", e);
             }
         }
+        self.tokio_shutdown = None;
+        self.socket = None;
+        self.settings = None;
+
         Ok(())
     }
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -90,7 +90,7 @@ pub fn swap_circuit_id(cell: &Vec<u8>, circuit_id: u32) -> Vec<u8> {
 }
 
 pub fn is_cell(prefix: &Vec<u8>, packet: &[u8]) -> bool {
-    packet.len() >= 29 && has_prefix(prefix, packet) && packet[22] == 0
+    packet.len() > 29 && has_prefix(prefix, packet) && packet[22] == 0
 }
 
 pub fn has_prefix(prefix: &[u8], packet: &[u8]) -> bool {

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -102,6 +102,15 @@ pub fn has_prefix(prefix: &[u8], packet: &[u8]) -> bool {
     true
 }
 
+pub fn has_prefixes(prefixes: &Vec<Vec<u8>>, packet: &[u8]) -> bool {
+    for prefix in prefixes.iter() {
+        if has_prefix(prefix, packet) {
+            return true;
+        }
+    }
+    false
+}
+
 pub fn decode_address(packet: &[u8], offset: usize) -> Result<(Address, usize)> {
     let buf = &packet[offset..];
     match buf[0] {

--- a/src/routing/exit.rs
+++ b/src/routing/exit.rs
@@ -9,7 +9,11 @@ use socks5_proto::Address;
 use tokio::{net::UdpSocket, task::JoinHandle};
 
 use crate::{
-    crypto::{Direction, SessionKeys}, payload, socket::TunnelSettings, stats::Stats, util
+    crypto::{Direction, SessionKeys},
+    payload,
+    socket::TunnelSettings,
+    stats::Stats,
+    util,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -145,7 +149,7 @@ impl ExitSocket {
                         Ok(n) => {
                             stats.lock().unwrap().add_up(&cell, n);
                             debug!("Forwarded packet from {} to {}", socket_addr, circuit_id)
-                        },
+                        }
                         Err(_) => error!("Could not tunnel cell for exit {}", circuit_id),
                     };
                 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -19,7 +19,7 @@ use crate::socks5::UDPAssociate;
 use crate::stats::Stats;
 use crate::util::Result;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TunnelSettings {
     pub prefix: Vec<u8>,
     pub prefixes: Vec<Vec<u8>>,
@@ -40,6 +40,18 @@ impl TunnelSettings {
             exit_addr: "[::]:0".parse().unwrap(),
             callback,
             handle,
+        }
+    }
+
+    pub fn clone(settings: Arc<TunnelSettings>, py: Python<'_>) -> Self {
+        TunnelSettings {
+            prefix: settings.prefix.clone(),
+            prefixes: settings.prefixes.clone(),
+            max_relay_early: settings.max_relay_early.clone(),
+            peer_flags: settings.peer_flags.clone(),
+            exit_addr: settings.exit_addr.clone(),
+            callback: settings.callback.clone_ref(py),
+            handle: settings.handle.clone(),
         }
     }
 }

--- a/src/socks5.rs
+++ b/src/socks5.rs
@@ -1,5 +1,5 @@
 use arc_swap::ArcSwap;
-use rand::seq::SliceRandom;
+use rand::prelude::IndexedRandom;
 use socks5_proto::{Address, UdpHeader};
 use std::io::Cursor;
 use std::net::Ipv4Addr;
@@ -155,7 +155,7 @@ fn select_circuit(
         Some(cid) => Some(*cid),
         None => {
             let options = get_options(&socket, &circuits);
-            let Some(&cid) = options.choose(&mut rand::thread_rng()) else {
+            let Some(&cid) = options.choose(&mut rand::rng()) else {
                 return None;
             };
             addr_to_cid.insert(address.clone(), cid);

--- a/src/speedtest.rs
+++ b/src/speedtest.rs
@@ -1,165 +1,172 @@
 use std::{
     collections::HashMap,
-    io::Cursor,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
+use arc_swap::ArcSwap;
 use pyo3::{types::IntoPyDict, PyObject, Python};
 use rand::{Rng, RngCore};
-use socks5_proto::{Address, UdpHeader};
-use tokio::{
-    net::UdpSocket,
-    sync::{broadcast, oneshot, OwnedSemaphorePermit, Semaphore},
-};
+use tokio::{net::UdpSocket, sync::broadcast};
 
-use crate::util;
+use crate::{routing::circuit::Circuit, socket::TunnelSettings, util::get_time_ms};
 
-pub async fn run_speedtest(
-    server_addr: String,
-    associate_port: u16,
-    num_packets: usize,
+pub async fn run_test(
+    settings: Arc<ArcSwap<TunnelSettings>>,
+    circuit_id: u32,
+    circuits: Arc<Mutex<HashMap<u32, Circuit>>>,
+    socket: Arc<UdpSocket>,
+    test_time: u16,
     request_size: u16,
     response_size: u16,
-    timeout_ms: usize,
-    window_size: usize,
+    target_rtt: u16,
     callback: PyObject,
+    callback_interval: u16,
 ) {
-    let (socket_tx, socket_rx) = oneshot::channel();
-
-    let msg_tx = tokio::sync::broadcast::Sender::new(window_size);
-    let recv_task = tokio::spawn(receive_and_broadcast(associate_port, socket_tx, msg_tx.clone()));
-    let socket = match socket_rx.await {
-        Ok(socket) => socket,
-        Err(e) => {
-            error!("Error while receiving speedtest socket: {}. Aborting test.", e);
-            return;
-        }
-    };
-
-    let semaphore = Arc::new(Semaphore::new(window_size));
+    let rtts = Arc::new(Mutex::new(Vec::<u16>::new()));
     let results = Arc::new(Mutex::new(HashMap::new()));
 
-    debug!("Sending packets with window={}", window_size);
-
-    for _ in 0..num_packets {
-        let permit = semaphore.clone().acquire_owned().await.unwrap();
-        tokio::spawn(send_and_wait(
-            Address::SocketAddress(server_addr.parse().unwrap()),
-            socket.clone(),
-            request_size,
-            response_size,
-            timeout_ms,
-            msg_tx.subscribe(),
+    let mut cb_task = None;
+    if callback_interval > 0 {
+        cb_task = Some(settings.load().handle.spawn(cb_loop(
+            Python::with_gil(|py| callback.clone_ref(py)),
+            callback_interval,
             results.clone(),
-            permit,
-        ));
+        )));
     }
 
-    debug!("All {} packets sent!", num_packets);
-    tokio::time::sleep(Duration::from_millis(timeout_ms.try_into().unwrap())).await;
+    let recv_task = settings.load().handle.spawn(receive_loop(
+        settings.load().test_channel.clone(),
+        results.clone(),
+        rtts.clone(),
+    ));
+
+    debug!("Testing circuit {}..", circuit_id);
+    let prefix = settings.load().prefix.clone();
+    let send_task = settings.load().handle.spawn(send_loop(
+        circuit_id,
+        circuits.clone(),
+        prefix,
+        socket.clone(),
+        request_size,
+        response_size,
+        target_rtt,
+        results.clone(),
+        rtts.clone(),
+    ));
+
+    debug!("Stopping test for circuit {}..", circuit_id);
+    tokio::time::sleep(Duration::from_millis((test_time).into())).await;
+    send_task.abort();
     recv_task.abort();
-    let _ =
-        Python::with_gil(|py| callback.call1(py, (results.lock().unwrap().clone().into_py_dict(py)?,)));
+    if let Some(task) = cb_task {
+        task.abort();
+    };
+
+    tokio::time::sleep(Duration::from_millis((target_rtt * 2).into())).await;
+    let _ = Python::with_gil(|py| {
+        callback.call1(py, (results.lock().unwrap().clone().into_py_dict(py)?, true))
+    });
+    debug!("Finished test for circuit {}", circuit_id);
 }
 
-pub async fn receive_and_broadcast(
-    associate_port: u16,
-    socket_tx: oneshot::Sender<Arc<UdpSocket>>,
-    tx: broadcast::Sender<(u32, usize)>,
+pub async fn receive_loop(
+    msg_tx: broadcast::Sender<(u32, usize)>,
+    results: Arc<Mutex<HashMap<u32, [usize; 4]>>>,
+    rtts: Arc<Mutex<Vec<u16>>>,
 ) {
-    let socket = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
-    let _ = socket.connect(format!("127.0.0.1:{}", associate_port)).await;
-    let _ = socket_tx.send(socket.clone());
+    let mut msg_rx = msg_tx.subscribe();
 
-    let mut buf = [0; 2048];
     loop {
-        match socket.recv(&mut buf).await {
-            Ok(n) => {
-                let mut packet = &buf[..n];
-                // Strip SOCKS5 header
-                let Ok(header) = UdpHeader::read_from(&mut Cursor::new(packet)).await else {
-                    error!("Failed to decode SOCKS5 header address");
-                    continue;
+        match msg_rx.recv().await {
+            Ok((tid, n)) => {
+                debug!("Received response for request {}", tid);
+                let mut rtt = 0;
+                if let Some(result) = results.lock().unwrap().get_mut(&tid) {
+                    result[2] = get_time_ms() as usize;
+                    result[3] = n;
+                    rtt = (result[2] - result[0]) as u16;
                 };
-                packet = &packet[header.serialized_len()..];
-
-                // Payload format: 'd' + 4-byte transaction ID + the exit IP + payload + 'e'
-                if packet.len() < 13 {
-                    error!("Dropping packet (response too small");
-                    continue;
+                if rtt != 0 {
+                    rtts.lock().unwrap().push(rtt);
                 }
-
-                // Broadcast transaction ID
-                let tid = u32::from_be_bytes(packet[1..5].try_into().unwrap());
-                let _ = tx.send((tid, n));
-                debug!("Broadcasting response for request {}", tid);
             }
-            Err(ref e) if e.kind() == tokio::io::ErrorKind::WouldBlock => {}
-            Err(e) => error!("Error while reading socket: {}", e),
-        }
+            Err(_) => {
+                error!("Error while receiving response");
+            }
+        };
     }
 }
 
-pub async fn send_and_wait(
-    target: Address,
+pub async fn send_loop(
+    circuit_id: u32,
+    circuits: Arc<Mutex<HashMap<u32, Circuit>>>,
+    prefix: Vec<u8>,
     socket: Arc<UdpSocket>,
     request_size: u16,
     response_size: u16,
-    timeout_ms: usize,
-    mut rx: broadcast::Receiver<(u32, usize)>,
+    target_rtt: u16,
     results: Arc<Mutex<HashMap<u32, [usize; 4]>>>,
-    _: OwnedSemaphorePermit,
+    rtts: Arc<Mutex<Vec<u16>>>,
 ) {
     let mut random_data = [0; 2048];
     rand::rng().fill_bytes(&mut random_data);
-    let payload = &random_data[..request_size as usize];
-    let tid: u32 = rand::rng().random();
-    let header = UdpHeader::new(0, target.clone());
-    let mut socks5_pkt = Vec::with_capacity(header.serialized_len());
-    if let Err(e) = header.write_to(&mut socks5_pkt).await {
-        error!("Error while writing SOCKS5 header: {}", e);
-        return;
-    };
-    socks5_pkt.extend_from_slice(&[b'd']);
-    socks5_pkt.extend_from_slice(&tid.to_be_bytes());
-    socks5_pkt.extend_from_slice(&response_size.to_be_bytes());
-    socks5_pkt.extend_from_slice(&payload);
-    socks5_pkt.extend_from_slice(&[b'e']);
 
-    match socket.send(&socks5_pkt).await {
-        Ok(size) => {
-            debug!("Sent request {} ({} bytes)", tid, size);
+    loop {
+        let mut sum: u16 = 0;
+        if rtts.lock().unwrap().len() > 10 {
+            sum = rtts.lock().unwrap().iter().rev().take(10).sum();
+        }
+        if sum / 10 > target_rtt {
+            tokio::time::sleep(Duration::from_millis(0)).await;
+        }
+
+        let tid: u32 = rand::rng().random();
+
+        let test_request = [
+            prefix.to_vec(),
+            vec![0],
+            circuit_id.to_be_bytes().to_vec(),
+            vec![0, 0, 21],
+            tid.to_be_bytes().to_vec(),
+            response_size.to_be_bytes().to_vec(),
+            random_data[..request_size as usize].to_vec(),
+        ]
+        .concat();
+
+        let (encrypted, target) = match circuits.lock().unwrap().get_mut(&circuit_id) {
+            Some(circuit) => {
+                let Ok(encrypted) = circuit.encrypt_outgoing_cell(test_request, 8) else {
+                    error!("Can't encrypt cell for circuit {}", circuit_id);
+                    break;
+                };
+                (encrypted, circuit.peer.clone())
+            }
+            None => {
+                error!("Can't find circuit {}", circuit_id);
+                break;
+            }
+        };
+
+        if let Ok(n) = socket.send_to(&encrypted, target).await {
             results
                 .lock()
                 .unwrap()
-                .insert(tid, [util::get_time_ms() as usize, size, 0, 0]);
-            let wait_for_tid = async {
-                loop {
-                    match rx.recv().await {
-                        Ok((tid_received, n)) => {
-                            debug!("Received {}, looking for {}", tid_received, tid);
-                            if tid_received == tid {
-                                debug!("Received response for request {}", tid);
-                                if let Some(result) = results.lock().unwrap().get_mut(&tid) {
-                                    result[2] = util::get_time_ms() as usize;
-                                    result[3] = n;
-                                    break;
-                                };
-                            }
-                        }
-                        Err(_) => {}
-                    }
-                }
-            };
-            if let Err(_) =
-                tokio::time::timeout(Duration::from_millis(timeout_ms.try_into().unwrap()), wait_for_tid)
-                    .await
-            {
-                warn!("Request {} timedout", tid);
-            }
+                .insert(tid, [get_time_ms() as usize, n, 0, 0]);
         }
-        Err(ref e) if e.kind() == tokio::io::ErrorKind::WouldBlock => {}
-        Err(e) => error!("Error while writing to socket: {}", e),
-    };
+    }
+}
+
+pub async fn cb_loop(
+    callback: PyObject,
+    cb_interval: u16,
+    results: Arc<Mutex<HashMap<u32, [usize; 4]>>>,
+) {
+    loop {
+        tokio::time::sleep(Duration::from_millis(cb_interval as u64)).await;
+        debug!("Calling Python callback (interval={})", cb_interval);
+        let _ = Python::with_gil(|py| {
+            callback.call1(py, (results.lock().unwrap().clone().into_py_dict(py)?, false))
+        });
+    }
 }

--- a/src/speedtest.rs
+++ b/src/speedtest.rs
@@ -112,9 +112,9 @@ pub async fn send_and_wait(
     _: OwnedSemaphorePermit,
 ) {
     let mut random_data = [0; 2048];
-    rand::thread_rng().fill_bytes(&mut random_data);
+    rand::rng().fill_bytes(&mut random_data);
     let payload = &random_data[..request_size as usize];
-    let tid: u32 = rand::thread_rng().gen();
+    let tid: u32 = rand::rng().random();
     let header = UdpHeader::new(0, target.clone());
     let mut socks5_pkt = Vec::with_capacity(header.serialized_len());
     if let Err(e) = header.write_to(&mut socks5_pkt).await {

--- a/src/speedtest.rs
+++ b/src/speedtest.rs
@@ -60,7 +60,7 @@ pub async fn run_speedtest(
     tokio::time::sleep(Duration::from_millis(timeout_ms.try_into().unwrap())).await;
     recv_task.abort();
     let _ =
-        Python::with_gil(|py| callback.call1(py, (results.lock().unwrap().clone().into_py_dict(py),)));
+        Python::with_gil(|py| callback.call1(py, (results.lock().unwrap().clone().into_py_dict(py)?,)));
 }
 
 pub async fn receive_and_broadcast(

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct Stat {
+    pub num_up: usize,
+    pub num_down: usize,
+    pub bytes_up: usize,
+    pub bytes_down: usize,
+}
+
+impl Stat {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    fn add_up(&mut self, size: usize) {
+        self.num_up += 1;
+        self.bytes_up += size;
+    }
+
+    fn add_down(&mut self, size: usize) {
+        self.num_down += 1;
+        self.bytes_down += size;
+    }
+
+    pub fn to_vec(&self) -> Vec<usize> {
+        vec![self.num_up, self.bytes_up, self.num_down, self.bytes_down]
+    }
+}
+
+pub struct Stats {
+    pub socket_stats: Stat,
+    pub msg_stats: HashMap<[u8; 22], HashMap<u8, Stat>>,
+}
+
+impl Stats {
+    pub fn new() -> Self {
+        Stats {
+            socket_stats: Stat::new(),
+            msg_stats: HashMap::new(),
+        }
+    }
+
+    pub fn add_up(&mut self, buf: &[u8], size: usize) {
+        self.socket_stats.add_up(size);
+
+        if size >= 23 {
+            let community: [u8; 22] = buf[..22].try_into().unwrap();
+            self.msg_stats
+                .entry(community)
+                .or_insert(HashMap::new())
+                .entry(buf[22])
+                .or_insert(Stat::new())
+                .add_up(size);
+        }
+    }
+
+    pub fn add_down(&mut self, buf: &[u8], size: usize) {
+        self.socket_stats.add_down(size);
+
+        if size >= 23 {
+            let community: [u8; 22] = buf[..22].try_into().unwrap();
+            self.msg_stats
+                .entry(community)
+                .or_insert(HashMap::new())
+                .entry(buf[22])
+                .or_insert(Stat::new())
+                .add_down(size);
+        }
+    }
+}


### PR DESCRIPTION
This PR does the following:
* Adds message statistics for all IPv8 + tunnel traffic.
* Drops messages with unknown prefixes. Until now, these were handed over to IPv8.
* Fix an issue with the socket not closing correctly when calling `Endpoint.close`.
* Updates all Rust dependencies to their most recent version.
* Updates GitHub workflows and adds support for Python 3.13.
* Adds test-request/response handlers. These were still being handled by Python, which made them unsuitable for measuring circuit throughput. The way we measure throughput has also changed, and we now slow down sending when a target RTT is surpassed.